### PR TITLE
Add dark mode with manual toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en"{% if page.force_light %} data-theme="light" data-theme-locked{% endif %}>
   <head>
     <title>{% if page.title %}{{ page.title }} – {% endif %}{{ site.name }} – {{ site.description }}</title>
 
@@ -7,6 +7,19 @@
 
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/style.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
+
+    <script>
+      // Apply persisted theme before paint to avoid a flash of the wrong theme.
+      (function () {
+        if (document.documentElement.hasAttribute('data-theme-locked')) return;
+        try {
+          var saved = localStorage.getItem('theme');
+          if (saved === 'dark' || saved === 'light') {
+            document.documentElement.setAttribute('data-theme', saved);
+          }
+        } catch (e) {}
+      })();
+    </script>
 
     <!-- Created with Jekyll Now - http://github.com/barryclark/jekyll-now -->
   </head>
@@ -26,6 +39,11 @@
             <a href="{{ site.baseurl }}/">Posts</a>
             <a href="{{ site.baseurl }}/emails">Emails</a>
             <a href="{{ site.baseurl }}/about">About</a>
+            <button id="theme-toggle" class="theme-toggle" type="button"
+                    aria-label="Toggle dark mode" title="Toggle dark mode">
+              <span class="theme-icon-moon" aria-hidden="true">☾</span>
+              <span class="theme-icon-sun" aria-hidden="true">☀</span>
+            </button>
           </nav>
         </header>
       </div>
@@ -42,6 +60,38 @@
         </footer>
       </div>
     </div>
+
+    <script>
+      (function () {
+        var btn = document.getElementById('theme-toggle');
+        if (!btn) return;
+        var root = document.documentElement;
+        var media = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+
+        function resolved() {
+          var explicit = root.getAttribute('data-theme');
+          if (explicit === 'dark' || explicit === 'light') return explicit;
+          return media && media.matches ? 'dark' : 'light';
+        }
+
+        btn.addEventListener('click', function () {
+          var next = resolved() === 'dark' ? 'light' : 'dark';
+          root.setAttribute('data-theme', next);
+          try { localStorage.setItem('theme', next); } catch (e) {}
+        });
+
+        // If the user has not chosen explicitly, follow live system changes.
+        if (media && media.addEventListener) {
+          media.addEventListener('change', function () {
+            try {
+              if (localStorage.getItem('theme')) return;
+            } catch (e) {}
+            // No data-theme attribute means we're already following the
+            // media query — nothing to do, CSS will repaint.
+          });
+        }
+      })();
+    </script>
 
     {% include analytics.html %}
   </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,11 +39,14 @@
             <a href="{{ site.baseurl }}/">Posts</a>
             <a href="{{ site.baseurl }}/emails">Emails</a>
             <a href="{{ site.baseurl }}/about">About</a>
+            {% unless page.force_light %}
             <button id="theme-toggle" class="theme-toggle" type="button"
-                    aria-label="Toggle dark mode" title="Toggle dark mode">
+                    aria-label="Toggle dark mode" title="Toggle dark mode"
+                    aria-pressed="false">
               <span class="theme-icon-moon" aria-hidden="true">☾</span>
               <span class="theme-icon-sun" aria-hidden="true">☀</span>
             </button>
+            {% endunless %}
           </nav>
         </header>
       </div>
@@ -61,6 +64,7 @@
       </div>
     </div>
 
+    {% unless page.force_light %}
     <script>
       (function () {
         var btn = document.getElementById('theme-toggle');
@@ -74,24 +78,31 @@
           return media && media.matches ? 'dark' : 'light';
         }
 
+        function syncPressed() {
+          btn.setAttribute('aria-pressed', resolved() === 'dark' ? 'true' : 'false');
+        }
+
+        syncPressed();
+
         btn.addEventListener('click', function () {
           var next = resolved() === 'dark' ? 'light' : 'dark';
           root.setAttribute('data-theme', next);
           try { localStorage.setItem('theme', next); } catch (e) {}
+          syncPressed();
         });
 
-        // If the user has not chosen explicitly, follow live system changes.
+        // When the user hasn't chosen explicitly, system theme changes flip
+        // the resolved theme via CSS — keep aria-pressed in sync so the
+        // toggle's announced state matches what the user sees.
         if (media && media.addEventListener) {
           media.addEventListener('change', function () {
-            try {
-              if (localStorage.getItem('theme')) return;
-            } catch (e) {}
-            // No data-theme attribute means we're already following the
-            // media query — nothing to do, CSS will repaint.
+            try { if (localStorage.getItem('theme')) return; } catch (e) {}
+            syncPressed();
           });
         }
       })();
     </script>
+    {% endunless %}
 
     {% include analytics.html %}
   </body>

--- a/_sass/_dark.scss
+++ b/_sass/_dark.scss
@@ -3,7 +3,10 @@
 //
 // Applied either explicitly (`<html data-theme="dark">`) or via the user's
 // browser preference when they have not chosen "light" manually.
-// Tool pages (e.g. /sid, /certutil) opt out via `data-theme-locked="light"`.
+// Tool pages (e.g. /sid, /certutil) set `force_light: true` in their front
+// matter, which causes the layout to add a boolean `data-theme-locked`
+// attribute on <html>; the auto-dark media query below skips elements
+// carrying that attribute.
 //
 
 @mixin dark-theme {

--- a/_sass/_dark.scss
+++ b/_sass/_dark.scss
@@ -1,0 +1,113 @@
+//
+// DARK MODE
+//
+// Applied either explicitly (`<html data-theme="dark">`) or via the user's
+// browser preference when they have not chosen "light" manually.
+// Tool pages (e.g. /sid, /certutil) opt out via `data-theme-locked="light"`.
+//
+
+@mixin dark-theme {
+  body {
+    background: #1a1a1a;
+    color: #d4d4d4;
+  }
+
+  h1, h2, h3, h4, h5, h6 { color: #f0f0f0; }
+  h4 { color: #a0a0a0; }
+
+  a, a:hover, a:active { color: #6ba8e0; }
+
+  // Headings and dates that wrap a link should keep their muted colour
+  // rather than picking up the accent blue.
+  h1 a, h2 a, h3 a, h4 a, h5 a, h6 a,
+  .date a { color: inherit; }
+
+  .date,
+  .site-description,
+  em.caption,
+  footer,
+  .emails-description,
+  .newsletter-description,
+  .post .footnotes {
+    color: #a0a0a0;
+  }
+
+  .site-name { color: #d4d4d4; }
+
+  .masthead { border-bottom-color: #333; }
+
+  nav a {
+    color: #d4d4d4;
+
+    @include mobile {
+      color: #6ba8e0;
+    }
+  }
+
+  .posts > .post {
+    border-bottom-color: #333;
+
+    .date { color: #a0a0a0; }
+  }
+
+  .post {
+    blockquote { background: #262626; }
+    img.tweet { border-color: #333; }
+  }
+
+  .pagination {
+    a {
+      background-color: #262626;
+      color: #d4d4d4;
+    }
+    a:hover {
+      background-color: #333;
+      color: #d4d4d4;
+    }
+    .page_number { color: #d4d4d4; }
+  }
+
+  .wrapper-footer {
+    background-color: #1f1f1f;
+    border-color: #333;
+  }
+
+  ::-moz-selection,
+  ::selection {
+    color: #fff;
+    background: #4183C4;
+  }
+
+  // Code blocks: dark surface; the existing Solarized accent colors carry
+  // over reasonably, but a few hardcoded greys read poorly on a dark bg.
+  pre.highlight {
+    background-color: #1f2933;
+    border-color: #2d3b48;
+    box-shadow: 3px 3px rgba(0, 0, 0, 0.3);
+  }
+
+  .highlight .nx { color: #93A1A1; }
+  .highlight .gh,
+  .highlight .gu { color: #d08758; }
+
+  // Theme toggle reflects the *resolved* theme: shows the sun (click to go
+  // light) when dark is active.
+  .theme-toggle {
+    color: #d4d4d4;
+    .theme-icon-sun { display: inline; }
+    .theme-icon-moon { display: none; }
+    &:hover { color: #6ba8e0; }
+  }
+}
+
+// Manual override: user clicked the toggle and chose dark.
+:root[data-theme="dark"] {
+  @include dark-theme;
+}
+
+// Auto: follow system preference unless the user has manually chosen light.
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme-locked]) {
+    @include dark-theme;
+  }
+}

--- a/certutil/index.html
+++ b/certutil/index.html
@@ -2,6 +2,7 @@
 layout: page
 title: certutil -dstemplate Parser
 description: Parse certutil -dstemplate output and surface ESC1/2/3/9/15/17 conditions on AD certificate templates.
+force_light: true
 ---
 
 <style>

--- a/sid/index.html
+++ b/sid/index.html
@@ -2,6 +2,7 @@
 layout: page
 title: AD SID Extension Encoder
 description: Generate the DER-encoded Microsoft NTDS Object SID certificate extension value from an Active Directory SID.
+force_light: true
 ---
 
 <style>

--- a/style.scss
+++ b/style.scss
@@ -451,9 +451,6 @@ footer {
   }
 }
 
-// Tool pages opt out of dark mode and don't need the toggle.
-:root[data-theme-locked] .theme-toggle { display: none; }
-
 // Settled on moving the import of syntax highlighting to the bottom of the CSS
 // ... Otherwise it really bloats up the top of the CSS file and makes it difficult to find the start
 @import "highlights";

--- a/style.scss
+++ b/style.scss
@@ -421,7 +421,41 @@ footer {
   color: $gray;
 }
 
+// Theme toggle button (dark-mode switch in the masthead)
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 20px;
+  padding: 4px 8px;
+  background: none;
+  border: none;
+  color: $darkGray;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  vertical-align: middle;
+
+  // Light is the default — show the moon (click to go dark).
+  .theme-icon-sun { display: none; }
+  .theme-icon-moon { display: inline; }
+
+  &:hover { color: $blue; }
+  &:focus-visible {
+    outline: 2px solid $blue;
+    outline-offset: 2px;
+  }
+
+  @include mobile {
+    margin: 0 10px;
+  }
+}
+
+// Tool pages opt out of dark mode and don't need the toggle.
+:root[data-theme-locked] .theme-toggle { display: none; }
+
 // Settled on moving the import of syntax highlighting to the bottom of the CSS
 // ... Otherwise it really bloats up the top of the CSS file and makes it difficult to find the start
 @import "highlights";
 @import "svg-icons";
+@import "dark";


### PR DESCRIPTION
## Summary
- Dark mode follows the browser's `prefers-color-scheme` by default, with a sun/moon toggle in the masthead that overrides and persists the choice in `localStorage`.
- A pre-paint inline script applies the saved theme before first render so there's no flash of the wrong colour scheme.
- Tool pages (`/sid`, `/certutil`) opt out via `force_light: true` front matter — the layout emits `data-theme-locked` so their inline-styled panels keep the existing light treatment.
- Heading and date links inherit their colour rather than picking up the accent blue, mirroring the light theme's behaviour.

## Test plan
- [ ] Toggle flips the theme and the choice survives a reload.
- [ ] With no saved choice, the page follows the OS dark/light setting.
- [ ] `/sid` and `/certutil` stay light regardless of OS preference and don't show the toggle.
- [ ] Post titles and dates on the index render in muted light grey (not blue) in dark mode.
- [ ] Code blocks remain readable on the dark background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)