### PR TITLE
Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# markeldo.com
+
+Source for my personal blog at [markeldo.com](https://markeldo.com) — posts on security, software engineering, and technology.
+
+Jekyll 3 site originally forked from [Jekyll Now](https://github.com/barryclark/jekyll-now), published via GitHub Pages' built-in build (the `github-pages` gem — no Actions workflow). Pushes to `master` trigger a rebuild.
+
+## Local development
+
+```sh
+bundle install --path vendor/bundle
+bundle exec jekyll serve --host 127.0.0.1 --port 4000 --watch
+```
+
+`Gemfile` / `Gemfile.lock` are gitignored. Production uses whatever `github-pages` gem version GitHub has pinned server-side, regardless of what's in a local Gemfile — so committing one would suggest control over the production build that doesn't actually exist.
+
+## Layout
+
+- `posts/_posts/` — blog posts (paginated on the index).
+- `emails/_posts/` — archived newsletter issues, listed at `/emails`.
+- `drafts/` — unpublished drafts (pass `--drafts` to `jekyll serve` to preview).
+- `sid/`, `certutil/` — self-contained single-page tools (encoders/parsers). The HTML is intentionally inlined so each page works as an offline download.
+- `_layouts/`, `_includes/`, `_sass/` — templates and styles. Dark mode lives in `_sass/_dark.scss` plus a pre-paint script in `_layouts/default.html`.
+
+See [`CLAUDE.md`](./CLAUDE.md) for more detail on the conventions and gotchas.
+
+## License
+
+Code is MIT-licensed (see [`LICENSE`](./LICENSE), inherited from Jekyll Now). Post content is © Mark Eldridge.


### PR DESCRIPTION
## Summary
- Add a top-level `README.md` describing what the repo is, how to run it locally, the directory layout, and where to find deeper docs.
- Notes the Gemfile-gitignore convention so a fresh clone isn't mysterious.

`README.md` is already in `_config.yml`'s `exclude:` list, so it won't appear in the published site.

## Test plan
- [ ] Sanity-check rendering on GitHub.
- [ ] Confirm `_site/README.html` is not generated on next build (already excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)